### PR TITLE
Add sign-in and sign-up pages

### DIFF
--- a/apps/cruse/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/cruse/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -35,6 +35,8 @@ export default function SignInPage() {
         </Typography>
       </Box>
       <SignIn
+        routing="path"
+        path="/sign-in"
         appearance={{
           elements: {
             rootBox: { width: '100%', maxWidth: 400 },

--- a/apps/cruse/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/cruse/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -35,6 +35,8 @@ export default function SignUpPage() {
         </Typography>
       </Box>
       <SignUp
+        routing="path"
+        path="/sign-up"
         appearance={{
           elements: {
             rootBox: { width: '100%', maxWidth: 400 },


### PR DESCRIPTION
## Summary
- Add CRUSE-branded sign-in page with Clerk `<SignIn>` component
- Add CRUSE-branded sign-up page with Clerk `<SignUp>` component
- Fix SSO callback routing with `routing="path"` props


Closes #25