### PR TITLE
#42: unauthenticated health endpoint

### DIFF
--- a/apps/cruse/backend/main.py
+++ b/apps/cruse/backend/main.py
@@ -83,6 +83,12 @@ log_buffer = LogRingBuffer(maxlen=500)
 # ─── REST Endpoints ──────────────────────────────────────────────
 
 
+@app.get("/api/health")
+async def health_check():
+    """Unauthenticated health check for load balancers and Docker."""
+    return {"status": "healthy"}
+
+
 @app.get("/api/systems")
 async def list_systems(_user: ClerkUser = Depends(get_current_user)):
     """Return the list of available agent networks."""

--- a/apps/cruse/docker-compose.yml
+++ b/apps/cruse/docker-compose.yml
@@ -16,11 +16,12 @@ services:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
       - CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
       - CLERK_ISSUER_URL=${CLERK_ISSUER_URL:-}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:3001}
     volumes:
       - ../../registries:/app/registries:ro
       - ../../coded_tools:/app/coded_tools:ro
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5001/api/systems"]
+      test: ["CMD", "curl", "-f", "http://localhost:5001/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- Add `GET /api/health` returning `{"status": "healthy"}` without JWT auth
- Update `docker-compose.yml` healthcheck from `/api/systems` to `/api/health`
- Pass `ALLOWED_ORIGINS` env var to backend service in docker-compose

Closes #42