### PR TITLE
#46: production docker compose

### DIFF
--- a/deploy/cruse/docker-compose.prod.yml
+++ b/deploy/cruse/docker-compose.prod.yml
@@ -1,0 +1,60 @@
+version: "3.8"
+
+services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_started
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: ../../
+      dockerfile: apps/cruse/Dockerfile.backend
+    expose:
+      - "5001"
+    environment:
+      - AGENT_MANIFEST_FILE=registries/manifest.hocon
+      - AGENT_TOOL_PATH=coded_tools
+      - PYTHONPATH=/app
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
+      - CLERK_ISSUER_URL=${CLERK_ISSUER_URL:-}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost}
+    volumes:
+      - ../../registries:/app/registries:ro
+      - ../../coded_tools:/app/coded_tools:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: "1.5"
+          memory: 3G
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ../../apps/cruse/frontend
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost/api}
+        NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-ws://localhost/ws}
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+        NEXT_PUBLIC_CLERK_SIGN_IN_URL: ${NEXT_PUBLIC_CLERK_SIGN_IN_URL:-/sign-in}
+        NEXT_PUBLIC_CLERK_SIGN_UP_URL: ${NEXT_PUBLIC_CLERK_SIGN_UP_URL:-/sign-up}
+    expose:
+      - "3000"
+    restart: unless-stopped

--- a/deploy/cruse/nginx.conf
+++ b/deploy/cruse/nginx.conf
@@ -1,0 +1,42 @@
+upstream backend {
+    server backend:5001;
+}
+
+upstream frontend {
+    server frontend:3000;
+}
+
+server {
+    listen 80;
+
+    # Backend API
+    location /api/ {
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket
+    location /ws/ {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+
+    # Frontend (catch-all)
+    location / {
+        proxy_pass http://frontend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `deploy/cruse/docker-compose.prod.yml` with 3 services: nginx (port 80), backend (internal only), frontend (internal only)
- Add `deploy/cruse/nginx.conf` reverse proxy: `/api/*` and `/ws/*` → backend, `/*` → frontend
- WebSocket upgrade headers and 300s read/send timeout for long-running agent sessions
- Backend resource limits (1.5 CPU, 3GB RAM)

Closes #46