### PR TITLE
#48: EC2 bootstrap setup script

### DIFF
--- a/deploy/cruse/.env.example
+++ b/deploy/cruse/.env.example
@@ -1,0 +1,24 @@
+# CRUSE Production Environment Variables
+# Copy to .env and fill in values before deploying.
+
+# ── LLM API Keys ──────────────────────────────────────────────
+OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+
+# ── Clerk Authentication ──────────────────────────────────────
+CLERK_SECRET_KEY=sk_live_...
+CLERK_ISSUER_URL=https://your-clerk-domain.clerk.accounts.dev
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_...
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+
+# ── CORS ──────────────────────────────────────────────────────
+# Set to your Elastic IP or domain (e.g. http://1.2.3.4)
+ALLOWED_ORIGINS=http://localhost
+
+# ── Frontend URLs (baked at build time) ───────────────────────
+# These must match how the browser reaches the backend via nginx.
+# With nginx on port 80, the browser talks to the same origin.
+NEXT_PUBLIC_API_URL=http://localhost/api
+NEXT_PUBLIC_WS_URL=ws://localhost/ws

--- a/deploy/cruse/setup.sh
+++ b/deploy/cruse/setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# EC2 bootstrap script for CRUSE production deployment.
+# Run as root (or via user_data) on a fresh Ubuntu 24.04 instance.
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/M-Elsaied/cruse-agentic-ui.git}"
+REPO_BRANCH="${REPO_BRANCH:-main}"
+INSTALL_DIR="/opt/cruse"
+
+echo "==> Updating system packages..."
+apt-get update -y
+apt-get upgrade -y
+
+echo "==> Installing Docker Engine..."
+apt-get install -y ca-certificates curl gnupg
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+    > /etc/apt/sources.list.d/docker.list
+
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+systemctl enable docker
+systemctl start docker
+
+echo "==> Cloning repository..."
+if [ -d "$INSTALL_DIR" ]; then
+    echo "    Directory exists, pulling latest..."
+    cd "$INSTALL_DIR"
+    git fetch origin
+    git reset --hard "origin/$REPO_BRANCH"
+else
+    git clone --branch "$REPO_BRANCH" "$REPO_URL" "$INSTALL_DIR"
+    cd "$INSTALL_DIR"
+fi
+
+echo "==> Setting up environment..."
+ENV_FILE="$INSTALL_DIR/deploy/cruse/.env"
+if [ ! -f "$ENV_FILE" ]; then
+    cp "$INSTALL_DIR/deploy/cruse/.env.example" "$ENV_FILE"
+    echo "WARNING: .env created from example. Edit $ENV_FILE with real values before starting."
+    echo "    Then run: cd $INSTALL_DIR/deploy/cruse && docker compose -f docker-compose.prod.yml up -d"
+    exit 0
+fi
+
+echo "==> Starting services..."
+cd "$INSTALL_DIR/deploy/cruse"
+docker compose -f docker-compose.prod.yml up -d --build
+
+echo "==> Done! Services starting. Check status with:"
+echo "    cd $INSTALL_DIR/deploy/cruse && docker compose -f docker-compose.prod.yml ps"


### PR DESCRIPTION
## Summary
- Add `deploy/cruse/.env.example` with all production env vars (LLM keys, Clerk, CORS, frontend URLs)
- Add `deploy/cruse/setup.sh` that bootstraps a fresh Ubuntu 24.04 EC2 instance: installs Docker + Compose, clones repo, creates `.env`, starts services

Closes #48