### PR TITLE
Fix dubious ownership in deploy workflow

### DIFF
--- a/.github/workflows/deploy-cruse.yml
+++ b/.github/workflows/deploy-cruse.yml
@@ -24,6 +24,7 @@ jobs:
           script: |
             set -euo pipefail
 
+            git config --global --add safe.directory /opt/cruse
             cd /opt/cruse
             BRANCH="${{ github.event.inputs.branch || 'main' }}"
             git fetch origin


### PR DESCRIPTION
Add git safe.directory before git operations in deploy script.