### PR TITLE
Exclude mp4/webm from Clerk middleware

### DIFF
--- a/apps/cruse/frontend/src/middleware.ts
+++ b/apps/cruse/frontend/src/middleware.ts
@@ -12,7 +12,7 @@ export default clerkMiddleware(async (auth, request) => {
 
 export const config = {
   matcher: [
-    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|mp4|webm)).*)',
     '/(api|trpc)(.*)',
   ],
 };


### PR DESCRIPTION
## Summary
- Adds `mp4|webm` to the Clerk middleware matcher exclusion list
- Without this, requests for `/demo.mp4` are intercepted by Clerk auth and redirected to sign-in, causing the hero video background to fail silently
