### PR TITLE
Fix auth code input visibility on dark theme

### DIFF
--- a/apps/cruse/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/cruse/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -202,8 +202,8 @@ export default function SignInPage() {
                   headerSubtitle: { color: '#94a3b8' },
                   formFieldLabel: { color: '#94a3b8' },
                   formFieldInput: {
-                    background: 'rgba(255,255,255,0.06)',
-                    borderColor: 'rgba(255,255,255,0.1)',
+                    background: 'rgba(255,255,255,0.12)',
+                    borderColor: 'rgba(255,255,255,0.25)',
                     color: '#f1f5f9',
                     '&:focus': {
                       borderColor: '#3b82f6',

--- a/apps/cruse/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/cruse/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -202,8 +202,8 @@ export default function SignUpPage() {
                   headerSubtitle: { color: '#94a3b8' },
                   formFieldLabel: { color: '#94a3b8' },
                   formFieldInput: {
-                    background: 'rgba(255,255,255,0.06)',
-                    borderColor: 'rgba(255,255,255,0.1)',
+                    background: 'rgba(255,255,255,0.12)',
+                    borderColor: 'rgba(255,255,255,0.25)',
                     color: '#f1f5f9',
                     '&:focus': {
                       borderColor: '#3b82f6',


### PR DESCRIPTION
## Summary
- Increased `formFieldInput` background opacity from `0.06` to `0.12` and border opacity from `0.1` to `0.25` on both sign-in and sign-up pages
- Fixes verification code input being nearly invisible against the `#0f172a` dark background



Closes #89