### PR TITLE
Show rate limit reset time in user's local timezone

### DIFF
--- a/apps/cruse/frontend/src/components/InputBar.tsx
+++ b/apps/cruse/frontend/src/components/InputBar.tsx
@@ -110,7 +110,7 @@ export function InputBar() {
           <Chip
             label={
               rateLimitRemaining <= 0
-                ? 'No requests left today. Resets at midnight UTC.'
+                ? `No requests left today. Resets at ${new Date(new Date().setUTCHours(24, 0, 0, 0)).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}.`
                 : `${rateLimitRemaining} request${rateLimitRemaining === 1 ? '' : 's'} left today`
             }
             size="small"


### PR DESCRIPTION
## Summary
- Converts the midnight UTC rate limit reset time to the user's local timezone
- Replaces hardcoded "Resets at midnight UTC" with a computed local time (e.g. "Resets at 7:00 PM")


Closes #87