### PR TITLE
Show actual form values instead of <form submitted>

### DIFF
--- a/apps/cruse/frontend/src/components/CruseLayout.tsx
+++ b/apps/cruse/frontend/src/components/CruseLayout.tsx
@@ -17,6 +17,17 @@ import { BackgroundEngine } from '@/components/theme/BackgroundEngine';
 import { SpotlightTour } from '@/components/tour/SpotlightTour';
 import { useWebSocket } from '@/hooks/useWebSocket';
 
+function formatFormData(data: Record<string, unknown>): string {
+  const entries = Object.entries(data).filter(
+    ([, v]) => v !== undefined && v !== null && v !== '',
+  );
+  if (entries.length === 0) return '<form submitted>';
+  const lines = entries.map(
+    ([k, v]) => `• ${k.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/[_-]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}: ${v}`,
+  );
+  return `Form submitted:\n${lines.join('\n')}`;
+}
+
 export function CruseLayout() {
   const muiTheme = useTheme();
   const isMobile = useMediaQuery(muiTheme.breakpoints.down('md'));
@@ -32,7 +43,7 @@ export function CruseLayout() {
 
   const handleMobileSubmit = useCallback(() => {
     if (Object.keys(widgetFormData).length > 0) {
-      sendMessage('<form submitted>', widgetFormData);
+      sendMessage(formatFormData(widgetFormData), widgetFormData);
       setWidgetSubmitted(true);
       setWidgetDrawerOpen(false);
     }

--- a/apps/cruse/frontend/src/components/InputBar.tsx
+++ b/apps/cruse/frontend/src/components/InputBar.tsx
@@ -23,6 +23,17 @@ function scrapeLegacyFormData(): Record<string, unknown> | null {
   return Object.keys(result).length > 0 ? result : null;
 }
 
+function formatFormData(data: Record<string, unknown>): string {
+  const entries = Object.entries(data).filter(
+    ([, v]) => v !== undefined && v !== null && v !== '',
+  );
+  if (entries.length === 0) return '<form submitted>';
+  const lines = entries.map(
+    ([k, v]) => `• ${k.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/[_-]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}: ${v}`,
+  );
+  return `Form submitted:\n${lines.join('\n')}`;
+}
+
 export function InputBar() {
   const [input, setInput] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -77,7 +88,7 @@ export function InputBar() {
     // Need either text or form data to send
     if (!text && !formData) return;
 
-    const messageText = text || '<form submitted>';
+    const messageText = text || formatFormData(formData!);
     sendMessage(messageText, formData);
     if (formData) {
       setWidgetSubmitted(true);


### PR DESCRIPTION
## Summary

Replace generic `<form submitted>` message with actual submitted values formatted as a readable list (e.g. `Form submitted:\n• Budget: 5000\n• Timeline: 3 months`)



Closes #103