### PR TITLE
#77: fix TS build error

### DIFF
--- a/apps/cruse/frontend/src/components/admin/AdminConversationsPanel.tsx
+++ b/apps/cruse/frontend/src/components/admin/AdminConversationsPanel.tsx
@@ -207,7 +207,7 @@ export function AdminConversationsPanel() {
                   />
                   {msg.metadata?.latency_ms != null && (
                     <Typography variant="caption" sx={{ opacity: 0.5 }}>
-                      {msg.metadata.latency_ms}ms
+                      {String(msg.metadata.latency_ms)}ms
                     </Typography>
                   )}
                   <Typography variant="caption" sx={{ opacity: 0.4, ml: 'auto' }}>


### PR DESCRIPTION
## Summary
- Fix TypeScript build error: `msg.metadata.latency_ms` (typed `unknown`) cannot be rendered as React child
- Wraps with `String()` to satisfy strict typing


Closes #77