### PR TITLE
#73: fix MUI5 TextField InputProps

### DIFF
--- a/apps/cruse/frontend/src/components/settings/ApiKeysPanel.tsx
+++ b/apps/cruse/frontend/src/components/settings/ApiKeysPanel.tsx
@@ -245,16 +245,14 @@ export function ApiKeysPanel() {
                     placeholder={`Enter your ${PROVIDER_LABELS[provider] || provider} API key`}
                     value={keyInput}
                     onChange={(e) => setKeyInput(e.target.value)}
-                    slotProps={{
-                      input: {
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            <IconButton size="small" onClick={() => setShowKey(!showKey)}>
-                              {showKey ? <VisibilityOff fontSize="small" /> : <Visibility fontSize="small" />}
-                            </IconButton>
-                          </InputAdornment>
-                        ),
-                      },
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton size="small" onClick={() => setShowKey(!showKey)}>
+                            {showKey ? <VisibilityOff fontSize="small" /> : <Visibility fontSize="small" />}
+                          </IconButton>
+                        </InputAdornment>
+                      ),
                     }}
                   />
                   <TextField


### PR DESCRIPTION
## Summary

- Fix `slotProps` → `InputProps` on TextField in ApiKeysPanel (MUI 5 API, not MUI 6)

## Context

The original PR #123 was merged before this fix was pushed. This is a follow-up to fix the Next.js build failure.