### PR TITLE
#127: fix read-only filesystem for generated networks

### DIFF
--- a/deploy/cruse/docker-compose.prod.yml
+++ b/deploy/cruse/docker-compose.prod.yml
@@ -38,6 +38,7 @@ services:
       - FGA_POLICY_FILE=plugins/authorization/openfga/sample_authorization_model.json
     volumes:
       - ../../registries:/app/registries:ro
+      - registries_generated:/app/registries/generated
       - ../../coded_tools:/app/coded_tools:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5001/api/health"]
@@ -116,3 +117,4 @@ services:
 
 volumes:
   pgdata:
+  registries_generated:


### PR DESCRIPTION
## Summary
- The `registries/` directory is mounted as read-only (`:ro`) in Docker, causing `OSError: [Errno 30] Read-only file system` when the network materializer tries to write to `registries/generated/`
- Adds a named Docker volume (`registries_generated`) mounted at `/app/registries/generated` to provide a writable layer on top of the read-only registries mount
