### PR TITLE
#127: fix nested volume mount on read-only parent

### DIFF
--- a/deploy/cruse/docker-compose.prod.yml
+++ b/deploy/cruse/docker-compose.prod.yml
@@ -37,8 +37,8 @@ services:
       - FGA_STORE_NAME=${FGA_STORE_NAME:-cruse}
       - FGA_POLICY_FILE=plugins/authorization/openfga/sample_authorization_model.json
     volumes:
-      - ../../registries:/app/registries:ro
-      - registries_generated:/app/registries/generated
+      # Not :ro — materializer writes custom networks to registries/generated/
+      - ../../registries:/app/registries
       - ../../coded_tools:/app/coded_tools:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5001/api/health"]
@@ -117,4 +117,3 @@ services:
 
 volumes:
   pgdata:
-  registries_generated:


### PR DESCRIPTION
## Summary
- PR #128 added a named volume overlay at `registries/generated/` on top of a `:ro` bind mount — but Docker cannot create a mountpoint inside a read-only filesystem, causing container startup to fail
- Fix: remove `:ro` from the registries bind mount so the materializer can write to `registries/generated/`
- Drop the separate `registries_generated` named volume (no longer needed)

## Why not :ro?
Docker cannot create a nested mountpoint (`/app/registries/generated`) inside a parent mount that is `:ro`. The only alternatives are:
- Remove `:ro` (this PR) — acceptable since the app only writes to `generated/` subdirectory
- Split registries into per-subdirectory mounts — fragile and over-engineered
