### PR TITLE
#127: fix MissingGreenlet on network create

### DIFF
--- a/apps/cruse/backend/network_routes.py
+++ b/apps/cruse/backend/network_routes.py
@@ -147,6 +147,7 @@ async def create_network(
         description=body.description,
     )
     await db.flush()
+    await db.refresh(net)
 
     # Materialize to disk + invalidate caches
     network_materializer.materialize(net)


### PR DESCRIPTION
## Summary
- After `db.flush()`, server-generated columns (`created_at`, `updated_at`) are not loaded on the ORM object
- Accessing them in `_network_to_detail()` triggers a synchronous lazy-load inside the async session, causing `MissingGreenlet` error
- Fix: `await db.refresh(net)` after flush to explicitly load all columns asynchronously
