### PR TITLE
#127: fix network CRUD ORM errors

### DIFF
--- a/apps/cruse/backend/network_routes.py
+++ b/apps/cruse/backend/network_routes.py
@@ -166,6 +166,8 @@ async def create_network(
     except Exception:  # pylint: disable=broad-exception-caught
         log.exception("Failed to materialize network %s — DB record saved but file not written", net.slug)
 
+    # Re-fetch after all DB operations — flush() inside set_materialized expires ORM attributes
+    net = await repo.get_by_id(net.id)
     return _network_to_detail(net)
 
 
@@ -229,6 +231,8 @@ async def update_network(
     except Exception:  # pylint: disable=broad-exception-caught
         log.exception("Failed to materialize network %s after update", net.slug)
 
+    # Re-fetch after all DB operations — flush() inside set_materialized expires ORM attributes
+    net = await repo.get_by_id(net.id)
     return _network_to_detail(net)
 
 


### PR DESCRIPTION
## Summary
- Re-fetch network object after all DB operations (create + update endpoints) to prevent `MissingGreenlet` error
- Root cause: `repo.set_materialized()` calls `flush()` which expires ORM attributes loaded by earlier `db.refresh()`, causing `_network_to_detail()` to trigger synchronous lazy-load in async context

