### PR TITLE
Fix widget behavior via server-side sly_data intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,20 +110,21 @@ cruse (front-man LLM)
 |--------|----------|-----------|
 | GUI output | Raw HTML (freeform) | JSON Schema (structured, validatable) |
 | Widget generation | Inline in front-man prompt | Dedicated `widget_generator` + `template_provider` |
-| Front-man instructions | ~15 lines, single step | ~30 lines, explicit 3-step protocol |
-| Widget skip logic | Always generates HTML | Can return `{"display": false}` |
+| Front-man instructions | ~15 lines, single step | Conditional; skips widget for info replies and post-submit |
+| Widget skip logic | Always generates HTML | `sly_data`-driven: suppressed for info replies, duplicates, post-submit |
 | Field types | Whatever HTML the LLM invents | 12 typed fields with validation |
 | Icons / colors | None | Material Design Icons + hex colors per widget |
 
 ### New Coded Tool: WidgetTemplateProvider
 
-`coded_tools/experimental/cruse_agent/widget_template_provider.py` — does not exist upstream.
+`coded_tools/experimental/cruse_widget_agent/widget_template_provider.py` — does not exist upstream.
 
 | Feature | Description |
 |---------|-------------|
 | `WIDGET_SCHEMA_TEMPLATE` | Base JSON Schema with placeholder fields for the LLM to fill |
 | `WIDGET_TYPE_EXAMPLES` | 12 field patterns (text, textarea, number, select, date, slider, etc.) |
 | `ICON_GUIDANCE` | 17 categories with 100+ Material Design icon names + selection principles |
+| `session_context` | Exposes prior submitted fields from `sly_data` so the LLM skips already-collected fields |
 
 ### Manifest Changes
 
@@ -177,11 +178,13 @@ for details.
  +------------------------------------------------------------------+
 ```
 
-**Request flow**: User sends a message via WebSocket → backend runs `CruseSession.chat()`
-in a thread pool → `cruse` front-man calls `domain_expert` (AAOSA Determine/Fulfill) then
-`widget_generator` → backend parses the `say:`/`gui:` response → emits typed WebSocket
-events (`chat_complete`, `widget_schema`, `agent_trace`, `done`) → frontend updates store
-and renders.
+**Request flow**: User sends a message via WebSocket → backend seeds `sly_data["widget_state"]`
+with any submitted form data → runs `CruseSession.chat()` in a thread pool → `cruse` front-man
+calls `domain_expert` (AAOSA Determine/Fulfill), then conditionally calls `widget_generator`
+(suppressed for informational responses and after form submissions) → `widget_generator` calls
+`template_provider` which reads `sly_data` to surface already-collected fields → backend parses
+the `say:`/`gui:` response → emits typed WebSocket events (`chat_complete`, `widget_schema`,
+`agent_trace`, `done`) → frontend updates store and renders.
 
 ---
 
@@ -388,7 +391,9 @@ using `@rjsf/mui`. Example:
 1. Agent response contains `gui:` block → backend emits `widget_schema` event
 2. Left panel slides open (420px) → `SchemaForm` renders the JSON Schema
 3. User fills form → presses Send → `form_data` attached to next WebSocket message
-4. Success overlay (1.8s) → widget clears → full-width chat resumes
+4. Backend records submitted fields into `sly_data["widget_state"]` so the agent chain
+   knows what was already collected and will not ask for the same fields again
+5. Success overlay (1.8s) → widget clears → full-width chat resumes
 
 ---
 
@@ -448,9 +453,9 @@ apps/cruse/
         ├── store/              # Zustand store
         └── types/              # TypeScript definitions
 
-coded_tools/experimental/cruse_agent/
+coded_tools/experimental/cruse_widget_agent/
 ├── call_agent.py               # Domain expert (upstream)
-└── widget_template_provider.py # Widget schemas (NEW)
+└── widget_template_provider.py # Widget schemas + sly_data state bridge (NEW)
 
 registries/experimental/
 ├── cruse_agent.hocon           # Agent network (modified)
@@ -467,7 +472,7 @@ registries/experimental/
 - **Widget learning** — track which fields users fill vs skip
 - **Multi-modal input** — support image and voice attachments
 - **Agent self-correction** — retry with template examples on parse failure
-- **Multi-turn widgets** — follow-up forms that refine based on previous submissions
+- **Multi-turn widgets** *(done)* — `sly_data["widget_state"]` tracks submitted fields across turns
 
 ### Performance
 

--- a/apps/cruse/backend/main.py
+++ b/apps/cruse/backend/main.py
@@ -418,7 +418,9 @@ async def websocket_chat(websocket: WebSocket, session_id: str, token: str = Que
                 user_input = f"{msg.text}\n\nForm submission context: {msg.form_data}"
                 # Seed sly_data with form submission so coded tools (e.g., WidgetTemplateProvider)
                 # can surface previously collected fields to the LLM and avoid duplicate widgets.
-                ws_sly_data = cruse_session.state_info.get("sly_data") if cruse_session.state_info is not None else None
+                ws_sly_data = (
+                    cruse_session.state_info.get("sly_data") if cruse_session.state_info is not None else None
+                )
                 if ws_sly_data is not None:
                     widget_state = ws_sly_data.setdefault("widget_state", {})
                     submitted_fields = widget_state.setdefault("submitted_fields", [])

--- a/apps/cruse/backend/main.py
+++ b/apps/cruse/backend/main.py
@@ -416,6 +416,14 @@ async def websocket_chat(websocket: WebSocket, session_id: str, token: str = Que
             user_input = msg.text
             if msg.form_data:
                 user_input = f"{msg.text}\n\nForm submission context: {msg.form_data}"
+                # Seed sly_data with form submission so coded tools (e.g., WidgetTemplateProvider)
+                # can surface previously collected fields to the LLM and avoid duplicate widgets.
+                ws_sly_data = cruse_session.state_info.get("sly_data") if cruse_session.state_info is not None else None
+                if ws_sly_data is not None:
+                    widget_state = ws_sly_data.setdefault("widget_state", {})
+                    submitted_fields = widget_state.setdefault("submitted_fields", [])
+                    submitted_fields.extend(k for k in msg.form_data if k not in submitted_fields)
+                    widget_state.setdefault("submission_data", {}).update(msg.form_data)
 
             timeout_manager.touch(session_id)
 

--- a/apps/cruse/backend/response_parser.py
+++ b/apps/cruse/backend/response_parser.py
@@ -30,6 +30,9 @@ def try_parse_json(content: str) -> Any:
     :param content: The string to attempt JSON parsing on.
     :return: Parsed JSON object if successful, None otherwise.
     """
+    if content is None:
+        return None
+
     # Try raw content first
     try:
         return json.loads(content)

--- a/apps/cruse/backend/streaming_bridge.py
+++ b/apps/cruse/backend/streaming_bridge.py
@@ -121,7 +121,10 @@ async def process_chat_message(
         # Best-effort: save assistant message + request log to DB (before emitting events
         # so we can include the DB message ID in the chat_complete payload for feedback)
         saved_message_id = await _persist_response(
-            cruse_session, response, trace_entries, latency_ms,
+            cruse_session,
+            response,
+            trace_entries,
+            latency_ms,
             next((c for k, c in blocks if k == "gui_json"), None),
         )
 

--- a/apps/cruse/backend/streaming_bridge.py
+++ b/apps/cruse/backend/streaming_bridge.py
@@ -120,8 +120,10 @@ async def process_chat_message(
 
         # Best-effort: save assistant message + request log to DB (before emitting events
         # so we can include the DB message ID in the chat_complete payload for feedback)
-        widget_schema = next((c for k, c in blocks if k == "gui_json"), None)
-        saved_message_id = await _persist_response(cruse_session, response, trace_entries, latency_ms, widget_schema)
+        saved_message_id = await _persist_response(
+            cruse_session, response, trace_entries, latency_ms,
+            next((c for k, c in blocks if k == "gui_json"), None),
+        )
 
         for kind, content in blocks:
             if kind == "say":

--- a/apps/cruse/backend/streaming_bridge.py
+++ b/apps/cruse/backend/streaming_bridge.py
@@ -120,7 +120,8 @@ async def process_chat_message(
 
         # Best-effort: save assistant message + request log to DB (before emitting events
         # so we can include the DB message ID in the chat_complete payload for feedback)
-        saved_message_id = await _persist_response(cruse_session, response, trace_entries, latency_ms)
+        widget_schema = next((c for k, c in blocks if k == "gui_json"), None)
+        saved_message_id = await _persist_response(cruse_session, response, trace_entries, latency_ms, widget_schema)
 
         for kind, content in blocks:
             if kind == "say":
@@ -145,9 +146,16 @@ async def process_chat_message(
 
 
 async def _persist_response(
-    cruse_session: CruseSession, response: str, trace_entries: list, latency_ms: int
+    cruse_session: CruseSession,
+    response: str,
+    trace_entries: list,
+    latency_ms: int,
+    widget_schema: dict | None = None,
 ) -> int | None:
     """Best-effort: save assistant message and request log to the database.
+
+    Persists the widget schema (if any) alongside the agent trace for
+    post-hoc analysis of widget behavior patterns.
 
     Returns the saved message's DB id, or None if persistence failed.
     """
@@ -169,6 +177,8 @@ async def _persist_response(
             metadata = {"latency_ms": latency_ms}
             if trace_entries:
                 metadata["agent_trace"] = trace_entries
+            if widget_schema is not None:
+                metadata["widget_schema"] = widget_schema
             msg = await MessageRepository(db).append(
                 cruse_session.conversation_id, "assistant", response, metadata=metadata
             )

--- a/coded_tools/basic/advanced_calculator/calculator_tool.py
+++ b/coded_tools/basic/advanced_calculator/calculator_tool.py
@@ -45,7 +45,7 @@ class CalculatorCodedTool(CodedTool):
             "exponentiate": [2, math.pow],
             "factorial": [
                 1,
-                lambda n: (math.factorial(int(n)) if n >= 0 else "Error: Factorial of negative numbers is undefined"),
+                lambda n: math.factorial(int(n)) if n >= 0 else "Error: Factorial of negative numbers is undefined",
             ],
             "isprime": [
                 1,
@@ -53,7 +53,7 @@ class CalculatorCodedTool(CodedTool):
             ],
             "squareroot": [
                 1,
-                lambda n: (math.sqrt(n) if n >= 0 else "Error: Square root of negative numbers is undefined"),
+                lambda n: math.sqrt(n) if n >= 0 else "Error: Square root of negative numbers is undefined",
             ],
             "log": [
                 1,
@@ -63,25 +63,25 @@ class CalculatorCodedTool(CodedTool):
             ],
             "log10": [
                 1,
-                lambda x: (math.log10(x) if x > 0 else "Error: Logarithm undefined for non-positive values"),
+                lambda x: math.log10(x) if x > 0 else "Error: Logarithm undefined for non-positive values",
             ],
             "log2": [
                 1,
-                lambda x: (math.log2(x) if x > 0 else "Error: Logarithm undefined for non-positive values"),
+                lambda x: math.log2(x) if x > 0 else "Error: Logarithm undefined for non-positive values",
             ],
             "sin": [1, math.sin],
             "cos": [1, math.cos],
             "tan": [
                 1,
-                lambda x: (math.tan(x) if (x % (math.pi / 2)) != 0 else "Error: Tangent undefined at π/2 + kπ"),
+                lambda x: math.tan(x) if (x % (math.pi / 2)) != 0 else "Error: Tangent undefined at π/2 + kπ",
             ],
             "asin": [
                 1,
-                lambda x: (math.asin(x) if -1 <= x <= 1 else "Error: Input out of domain for arcsin"),
+                lambda x: math.asin(x) if -1 <= x <= 1 else "Error: Input out of domain for arcsin",
             ],
             "acos": [
                 1,
-                lambda x: (math.acos(x) if -1 <= x <= 1 else "Error: Input out of domain for arccos"),
+                lambda x: math.acos(x) if -1 <= x <= 1 else "Error: Input out of domain for arccos",
             ],
             "atan": [1, math.atan],
             "sinh": [1, math.sinh],
@@ -90,7 +90,7 @@ class CalculatorCodedTool(CodedTool):
             "gcd": [2, lambda a, b: math.gcd(int(a), int(b))],
             "lcm": [
                 2,
-                lambda a, b: (abs(int(a) * int(b)) // math.gcd(int(a), int(b)) if a and b else 0),
+                lambda a, b: abs(int(a) * int(b)) // math.gcd(int(a), int(b)) if a and b else 0,
             ],
             "mod": [2, lambda a, b: a % b if b != 0 else "Error: Modulo by zero"],
             "ceil": [1, math.ceil],

--- a/coded_tools/experimental/cruse_widget_agent/widget_template_provider.py
+++ b/coded_tools/experimental/cruse_widget_agent/widget_template_provider.py
@@ -276,9 +276,30 @@ class WidgetTemplateProvider(CodedTool):
         ],
     }
 
+    @staticmethod
+    def _get_widget_context(sly_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract widget session context from sly_data.
+
+        Reads the widget_state bulletin board to provide the LLM with
+        awareness of previously submitted form data and widget history.
+
+        :param sly_data: The sly_data dictionary from the agent chain.
+        :return: A context dict suitable for inclusion in the LLM-visible response.
+        """
+        widget_state = sly_data.get("widget_state", {})
+        return {
+            "previously_submitted": widget_state.get("submission_data", {}),
+            "fields_already_collected": widget_state.get("submitted_fields", []),
+            "last_widget_fields": widget_state.get("last_widget_fields", []),
+            "widget_count_this_session": widget_state.get("widget_count", 0),
+        }
+
     def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
         """
-        Provides widget schema template and examples.
+        Provides widget schema template, examples, and session context.
+
+        Reads ``sly_data["widget_state"]`` to surface previously submitted
+        form data and widget history so the LLM can avoid duplicate fields.
 
         :param args: An argument dictionary whose keys are the parameters
             to the coded tool and whose values are the values passed for
@@ -337,6 +358,13 @@ class WidgetTemplateProvider(CodedTool):
                     "Icons are displayed prominently - choose ones that match the widget purpose",
                 ],
             }
+
+        # Always include session context so the LLM knows what was already collected
+        result["session_context"] = self._get_widget_context(sly_data)
+
+        # Track this invocation in sly_data for downstream awareness
+        widget_state = sly_data.setdefault("widget_state", {})
+        widget_state["widget_count"] = widget_state.get("widget_count", 0) + 1
 
         return json.dumps(result, indent=2)
 

--- a/registries/experimental/cruse_agent.hocon
+++ b/registries/experimental/cruse_agent.hocon
@@ -85,7 +85,7 @@
 
             "instructions": """
 You are the CRUSE (Context Reactive User Experience) front-man agent. You orchestrate two tools to provide
-rich, form-augmented responses to user inquiries. You MUST always call BOTH tools in sequence.
+rich, form-augmented responses to user inquiries.
 
 ## Step 1: Call domain_expert (AAOSA Protocol)
 
@@ -94,13 +94,26 @@ domain_expert uses the AAOSA protocol with inquiry/mode parameters.
 - If relevant, call domain_expert with mode="Fulfill" to get the full response.
 - domain_expert is the subject-matter authority — never answer without consulting it.
 
-## Step 2: Call widget_generator (ALWAYS, after domain_expert)
+## Step 2: Decide whether to call widget_generator
 
-widget_generator is NOT an AAOSA agent — it uses different parameters.
-ALWAYS call widget_generator after getting the domain_expert response. Pass it:
-- conversation_context: the full conversation so far INCLUDING the domain_expert response
-- user_intent: a brief summary of what the user wants (e.g. "request_time_off", "report_expense")
-widget_generator will return either a JSON Schema widget or {{"display": false}}.
+After getting the domain_expert response, decide if a widget is needed.
+
+**Call widget_generator ONLY when the domain_expert response:**
+- Explicitly asks the user for structured input (dates, preferences, selections, amounts)
+- Indicates the user needs to choose between options before proceeding
+- Starts a new step that requires collecting NEW information from the user
+
+**Do NOT call widget_generator when:**
+- The user just submitted a form (message contains "Form submitted:" or "Form submission context:")
+- The domain_expert gave a final answer, confirmation, or summary with no follow-up needed
+- The response is informational (search results, recommendations, explanations, status updates)
+- The domain_expert is still searching or processing and asks the user to wait
+- A form with the same or similar fields was already shown this session
+
+**If you call widget_generator, pass:**
+- conversation_context: the domain_expert response verbatim — do NOT summarize or paraphrase it
+- user_intent: derived DIRECTLY from the domain_expert response topic (if domain_expert talks about hotels, use "book_hotel" not "book_meeting_room")
+- previous_widget: if a form was previously shown, include its JSON to avoid repeating the same fields
 
 ## Step 3: Format your response
 
@@ -110,10 +123,10 @@ Use these prefixes:
 
 ## Critical Rules:
 
-- You MUST call BOTH domain_expert AND widget_generator for every inquiry. Never skip widget_generator.
 - NEVER generate HTML. All gui: content must be JSON Schema from widget_generator.
 - The gui: block must contain ONLY the raw JSON object from widget_generator — no markdown fences, no wrapping text.
 - If widget_generator returns {{"display": false}}, omit the gui: block entirely and only use say:.
+- If you did not call widget_generator, respond with say: only — no gui: block.
 - Do not fabricate content — only present what your tools return.
 - Always start your responses with 'say:' and/or 'gui:'.
             """,
@@ -162,23 +175,25 @@ Use these prefixes:
 You are a widget generation specialist for the CRUSE (Context Reactive User Experience) system.
 Your job is to analyze conversation context and generate appropriate JSON schema definitions for dynamic widgets.
 
-IMPORTANT: Always use your template_provider tool first to get the widget schema template, examples, and available icons.
+IMPORTANT: Always call your template_provider tool FIRST — it returns the widget template AND
+a session_context block showing what fields have already been collected from the user.
 
 ## Your Process:
 
-1. **Understand the Context**
-   - Analyze the conversation to understand what the user wants to accomplish
-   - Identify what information needs to be collected from the user
-   - Determine the most appropriate field types for each piece of information
-   - **Determine if a widget is actually needed** - see "When NOT to Display a Widget" section below
+1. **Call template_provider first (request_type: "full")**
+   - Read the session_context it returns:
+     - "fields_already_collected": fields the user already submitted — do NOT ask for these again
+     - "previously_submitted": the actual values already provided
+     - "last_widget_fields": fields in the most recent widget shown
+   - Determine if a widget is actually needed — see "When NOT to Display" below
 
-2. **Get the Template**
-   - Call your template_provider tool with request_type: "full"
-   - Use the template structure as your base
-   - Reference the widget_type_examples for common field patterns
+2. **Understand the Context**
+   - Analyze the conversation to understand what NEW information is still needed
+   - The widget must ONLY collect information not already in session_context
 
 3. **Generate the Widget Schema**
    - Replace all <PLACEHOLDERS> with actual values based on the conversation context
+   - Exclude any fields listed in session_context.fields_already_collected
    - Choose appropriate field types (text, number, boolean, select, date, etc.)
    - Set proper validations (required fields, min/max values, patterns, etc.)
    - Add helpful descriptions and examples for each field
@@ -196,14 +211,27 @@ IMPORTANT: Always use your template_provider tool first to get the widget schema
 
 ## When NOT to Display a Widget:
 
-If based on the conversation context, a widget is NOT necessary, return ONLY:
+If a widget is NOT necessary, return ONLY:
 {{"display": false}}
 
 A widget is NOT necessary when:
-   - User is just having a casual conversation and no input is needed from the user
+   - The information that would fill the widget was already submitted (check session_context.fields_already_collected)
+   - The user just submitted a form — do NOT show another form with the same or overlapping fields
+   - All needed data has already been collected across prior turns
+   - The response is informational (search results, recommendations, confirmations, summaries)
+   - The conversation is casual and no structured input is required
+   - The agent is still processing and asks the user to wait
 
 ## When to Display a Widget:
-   - The conversation hints to any options for the user to select from
+   - The conversation explicitly requires NEW structured input from the user
+   - There are specific fields to collect that are NOT already in session_context.fields_already_collected
+   - The conversation has moved to a genuinely new step requiring different information
+
+## Multi-Turn Wizard Behavior:
+   - Each widget represents ONE step in a potential multi-step flow
+   - Use session_context.fields_already_collected to determine what step we are on
+   - If prior fields exist, the new widget should only ask for the NEXT set of fields
+   - Pre-fill or reference previously submitted values in descriptions where helpful
 
 ## Widget Field Type Selection Guide:
 

--- a/tests/apps/cruse/backend/test_response_parser.py
+++ b/tests/apps/cruse/backend/test_response_parser.py
@@ -1,0 +1,135 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Unit tests for apps.cruse.backend.response_parser."""
+
+
+from apps.cruse.backend.response_parser import parse_response_blocks
+from apps.cruse.backend.response_parser import try_parse_json
+
+
+class TestTryParseJson:  # pylint: disable=missing-function-docstring
+    """Tests for try_parse_json()."""
+
+    def test_valid_json_object(self):
+        assert try_parse_json('{"title": "Hello"}') == {"title": "Hello"}
+
+    def test_valid_json_array(self):
+        assert try_parse_json("[1, 2, 3]") == [1, 2, 3]
+
+    def test_invalid_json_returns_none(self):
+        assert try_parse_json("not json at all") is None
+
+    def test_strips_markdown_json_fence(self):
+        content = '```json\n{"display": false}\n```'
+        assert try_parse_json(content) == {"display": False}
+
+    def test_strips_markdown_bare_fence(self):
+        content = '```\n{"key": "value"}\n```'
+        assert try_parse_json(content) == {"key": "value"}
+
+    def test_fence_with_invalid_json_returns_none(self):
+        content = "```json\nnot valid json\n```"
+        assert try_parse_json(content) is None
+
+    def test_empty_string_returns_none(self):
+        assert try_parse_json("") is None
+
+    def test_none_returns_none(self):
+        assert try_parse_json(None) is None
+
+
+class TestParseResponseBlocks:  # pylint: disable=missing-function-docstring
+    """Tests for parse_response_blocks()."""
+
+    def test_say_only(self):
+        blocks = parse_response_blocks("say: Hello, how can I help?")
+        assert len(blocks) == 1
+        assert blocks[0] == ("say", "Hello, how can I help?")
+
+    def test_say_with_multiline(self):
+        response = "say: Line 1\nLine 2\nLine 3"
+        blocks = parse_response_blocks(response)
+        assert len(blocks) == 1
+        assert blocks[0][0] == "say"
+        assert "Line 1" in blocks[0][1]
+        assert "Line 3" in blocks[0][1]
+
+    def test_say_and_gui_json(self):
+        response = 'say: Here is a form\ngui: {"title": "Test", "schema": {}}'
+        blocks = parse_response_blocks(response)
+        assert len(blocks) == 2
+        assert blocks[0] == ("say", "Here is a form")
+        assert blocks[1][0] == "gui_json"
+        assert blocks[1][1]["title"] == "Test"
+
+    def test_gui_display_false(self):
+        response = 'say: No widget needed\ngui: {"display": false}'
+        blocks = parse_response_blocks(response)
+        assert len(blocks) == 2
+        assert blocks[1][0] == "gui_json"
+        assert blocks[1][1]["display"] is False
+
+    def test_gui_invalid_json_becomes_gui_html(self):
+        response = "say: Here\ngui: <div>Some HTML</div>"
+        blocks = parse_response_blocks(response)
+        assert len(blocks) == 2
+        assert blocks[1][0] == "gui_html"
+        assert "<div>" in blocks[1][1]
+
+    def test_gui_with_markdown_fences(self):
+        response = 'say: Fill this out\ngui: ```json\n{"title": "Form"}\n```'
+        blocks = parse_response_blocks(response)
+        assert len(blocks) == 2
+        assert blocks[1][0] == "gui_json"
+        assert blocks[1][1]["title"] == "Form"
+
+    def test_no_prefix_fallback(self):
+        """Response without say:/gui: prefixes treated as single say block."""
+        blocks = parse_response_blocks("Just a plain response with no prefix")
+        assert len(blocks) == 1
+        assert blocks[0] == ("say", "Just a plain response with no prefix")
+
+    def test_empty_response(self):
+        blocks = parse_response_blocks("")
+        assert len(blocks) == 0
+
+    def test_whitespace_only_response(self):
+        blocks = parse_response_blocks("   \n  \n  ")
+        assert len(blocks) == 0
+
+    def test_multiple_gui_blocks(self):
+        response = 'gui: {"title": "A"}\ngui: {"title": "B"}'
+        blocks = parse_response_blocks(response)
+        assert len(blocks) == 2
+        assert blocks[0][1]["title"] == "A"
+        assert blocks[1][1]["title"] == "B"
+
+    def test_case_insensitive_prefix(self):
+        """Prefixes are matched case-insensitively."""
+        response = 'Say: Hello\nGUI: {"display": false}'
+        blocks = parse_response_blocks(response)
+        assert len(blocks) == 2
+        assert blocks[0][0] == "say"
+        assert blocks[1][0] == "gui_json"
+
+    def test_multiline_gui_json(self):
+        """Multi-line gui: JSON block is parsed correctly."""
+        response = 'say: Here\ngui: {\n  "title": "Multi",\n  "schema": {}\n}'
+        blocks = parse_response_blocks(response)
+        assert len(blocks) == 2
+        assert blocks[1][0] == "gui_json"
+        assert blocks[1][1]["title"] == "Multi"

--- a/tests/apps/cruse/backend/test_response_parser.py
+++ b/tests/apps/cruse/backend/test_response_parser.py
@@ -16,7 +16,6 @@
 
 """Unit tests for apps.cruse.backend.response_parser."""
 
-
 from apps.cruse.backend.response_parser import parse_response_blocks
 from apps.cruse.backend.response_parser import try_parse_json
 

--- a/tests/coded_tools/experimental/__init__.py
+++ b/tests/coded_tools/experimental/__init__.py
@@ -1,0 +1,15 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT

--- a/tests/coded_tools/experimental/cruse_widget_agent/__init__.py
+++ b/tests/coded_tools/experimental/cruse_widget_agent/__init__.py
@@ -1,0 +1,15 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT

--- a/tests/coded_tools/experimental/cruse_widget_agent/test_widget_template_provider.py
+++ b/tests/coded_tools/experimental/cruse_widget_agent/test_widget_template_provider.py
@@ -1,0 +1,127 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Unit tests for WidgetTemplateProvider coded tool.
+
+Tests the sly_data-based widget session context that enables
+the LLM to avoid generating duplicate widgets.
+"""
+
+import json
+
+import pytest
+
+from coded_tools.experimental.cruse_widget_agent.widget_template_provider import WidgetTemplateProvider
+
+
+@pytest.fixture
+def provider():
+    """Create a WidgetTemplateProvider instance."""
+    return WidgetTemplateProvider()
+
+
+class TestWidgetTemplateProvider:  # pylint: disable=redefined-outer-name
+    """Tests for WidgetTemplateProvider.invoke()."""
+
+    def test_template_request_returns_template(self, provider):
+        """request_type=template returns only the template."""
+        result = json.loads(provider.invoke({"request_type": "template"}, {}))
+        assert "template" in result
+        assert "widget_type_examples" not in result
+
+    def test_examples_request_returns_examples(self, provider):
+        """request_type=examples returns only the examples."""
+        result = json.loads(provider.invoke({"request_type": "examples"}, {}))
+        assert "widget_type_examples" in result
+        assert "template" not in result
+
+    def test_full_request_returns_all_sections(self, provider):
+        """request_type=full returns template, examples, icons, instructions, and session_context."""
+        result = json.loads(provider.invoke({"request_type": "full"}, {}))
+        assert "template" in result
+        assert "widget_type_examples" in result
+        assert "icon_guidance" in result
+        assert "instructions" in result
+        assert "session_context" in result
+
+    def test_session_context_empty_sly_data(self, provider):
+        """Empty sly_data yields empty-default session context."""
+        result = json.loads(provider.invoke({"request_type": "full"}, {}))
+        ctx = result["session_context"]
+        assert ctx["previously_submitted"] == {}
+        assert ctx["fields_already_collected"] == []
+        assert ctx["last_widget_fields"] == []
+        assert ctx["widget_count_this_session"] == 0
+
+    def test_session_context_with_submitted_fields(self, provider):
+        """sly_data with widget_state surfaces previously submitted data."""
+        sly_data = {
+            "widget_state": {
+                "submitted_fields": ["checkInDate", "checkOutDate", "budget"],
+                "submission_data": {"checkInDate": "2026-03-09", "checkOutDate": "2026-03-10", "budget": 250},
+                "last_widget_fields": ["checkInDate", "checkOutDate", "budget", "preferences"],
+                "widget_count": 1,
+            }
+        }
+        result = json.loads(provider.invoke({"request_type": "full"}, sly_data))
+        ctx = result["session_context"]
+        assert ctx["previously_submitted"]["checkInDate"] == "2026-03-09"
+        assert ctx["previously_submitted"]["budget"] == 250
+        assert "checkInDate" in ctx["fields_already_collected"]
+        assert ctx["last_widget_fields"] == ["checkInDate", "checkOutDate", "budget", "preferences"]
+        assert ctx["widget_count_this_session"] == 1
+
+    def test_session_context_included_in_non_full_requests(self, provider):
+        """session_context is included even for template-only requests."""
+        sly_data = {"widget_state": {"submission_data": {"name": "Alice"}}}
+        result = json.loads(provider.invoke({"request_type": "template"}, sly_data))
+        assert "session_context" in result
+        assert result["session_context"]["previously_submitted"]["name"] == "Alice"
+
+    def test_widget_count_incremented_in_sly_data(self, provider):
+        """Each invocation increments widget_count in sly_data."""
+        sly_data = {}
+        provider.invoke({"request_type": "full"}, sly_data)
+        assert sly_data["widget_state"]["widget_count"] == 1
+
+        provider.invoke({"request_type": "full"}, sly_data)
+        assert sly_data["widget_state"]["widget_count"] == 2
+
+    def test_widget_count_preserves_existing_state(self, provider):
+        """Incrementing widget_count does not overwrite other widget_state keys."""
+        sly_data = {
+            "widget_state": {
+                "submitted_fields": ["email"],
+                "widget_count": 3,
+            }
+        }
+        provider.invoke({"request_type": "full"}, sly_data)
+        assert sly_data["widget_state"]["widget_count"] == 4
+        assert sly_data["widget_state"]["submitted_fields"] == ["email"]
+
+    def test_sly_data_other_keys_untouched(self, provider):
+        """Provider does not modify unrelated sly_data keys."""
+        sly_data = {"selected_agent": "registries/foo.hocon", "agent_session": "mock_session"}
+        provider.invoke({"request_type": "full"}, sly_data)
+        assert sly_data["selected_agent"] == "registries/foo.hocon"
+        assert sly_data["agent_session"] == "mock_session"
+
+    def test_default_request_type_is_full(self, provider):
+        """Omitting request_type defaults to full."""
+        result = json.loads(provider.invoke({}, {}))
+        assert "template" in result
+        assert "instructions" in result
+        assert "session_context" in result

--- a/tests/fixtures/experimental/cruse_agent/widget_info_no_widget.hocon
+++ b/tests/fixtures/experimental/cruse_agent/widget_info_no_widget.hocon
@@ -1,0 +1,65 @@
+
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# Widget suppression test: when the user asks a casual or informational
+# question the agent should respond with plain text only — no widget.
+# Addresses issues #101 and #90.
+
+{
+    "agent": "experimental/cruse_agent",
+
+    "connections": ["direct"],
+
+    "timeout_in_seconds": 300,
+
+    # Allow 1 success in 2 attempts — LLM response for casual questions can vary.
+    "success_ratio": "1/2",
+
+    "interactions": [
+        {
+            # Turn 1: Casual greeting — no input needed, no widget expected.
+            "sly_data": {
+                "selected_agent": "industry/booking"
+            },
+
+            "text": "Hi, what can you help me with?",
+
+            "continue_conversation": true,
+
+            "response": {
+                "text": {
+                    "gist": "The assistant describes travel-related capabilities it can help with"
+                }
+            }
+        },
+        {
+            # Turn 2: Informational question — answer should be text only, no form.
+            "sly_data": {
+                "selected_agent": "industry/booking"
+            },
+
+            "text": "What are the best neighborhoods to stay in when visiting San Francisco?",
+
+            "response": {
+                "text": {
+                    "gist": "The assistant provides information relevant to visiting or staying in San Francisco",
+                    "not_gist": "The assistant asks the user to submit a form with travel dates"
+                }
+            }
+        }
+    ]
+}

--- a/tests/fixtures/experimental/cruse_agent/widget_matches_context.hocon
+++ b/tests/fixtures/experimental/cruse_agent/widget_matches_context.hocon
@@ -1,0 +1,47 @@
+
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# Widget context match test: the widget shown should be relevant to the
+# actual topic of the user request (hotel booking ≠ meeting room booking).
+# Addresses issues #141 and #101.
+
+{
+    "agent": "experimental/cruse_agent",
+
+    "connections": ["direct"],
+
+    "timeout_in_seconds": 300,
+
+    "interactions": [
+        {
+            # Turn 1: User asks specifically about hotel — widget must be hotel-related.
+            # sly_data seeds selected_agent so domain_expert (CallAgent) knows which agent to call.
+            "sly_data": {
+                "selected_agent": "industry/booking"
+            },
+
+            "text": "I want to book a hotel room for a business trip to New York",
+
+            "response": {
+                "text": {
+                    "gist": "The assistant responds about hotel or travel booking for the New York trip",
+                    "not_gist": "The assistant talks about meeting room booking or office scheduling"
+                }
+            }
+        }
+    ]
+}

--- a/tests/fixtures/experimental/cruse_agent/widget_multi_turn.hocon
+++ b/tests/fixtures/experimental/cruse_agent/widget_multi_turn.hocon
@@ -1,0 +1,71 @@
+
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# Multi-turn wizard test: after a partial form submission the agent should
+# ask only for the remaining fields — not repeat fields already provided.
+# Addresses issue #14.
+
+{
+    "agent": "experimental/cruse_agent",
+
+    "connections": ["direct"],
+
+    "timeout_in_seconds": 300,
+
+    "interactions": [
+        {
+            # Turn 1: User initiates a hotel search in Paris.
+            "sly_data": {
+                "selected_agent": "industry/booking"
+            },
+
+            "text": "I need to book a hotel in Paris for my anniversary trip",
+
+            "continue_conversation": true,
+
+            "response": {
+                "text": {
+                    "gist": "The assistant responds about hotel booking in Paris or anniversary travel"
+                }
+            }
+        },
+        {
+            # Turn 2: User provides check-in date only — agent should not ask for it again.
+            # widget_state is seeded to simulate that checkInDate was already submitted.
+            "sly_data": {
+                "selected_agent": "industry/booking",
+                "widget_state": {
+                    "submitted_fields": ["checkInDate"],
+                    "submission_data": {
+                        "checkInDate": "2026-06-10"
+                    }
+                }
+            },
+
+            "text": "Form submitted:\n• Check In Date: 2026-06-10\n\nForm submission context: {'checkInDate': '2026-06-10'}",
+
+            "continue_conversation": true,
+
+            "response": {
+                "text": {
+                    "gist": "The assistant acknowledges the check-in date or provides information to continue the hotel booking",
+                    "not_gist": "The assistant asks again for the check-in date of June 10 that was already provided"
+                }
+            }
+        }
+    ]
+}

--- a/tests/fixtures/experimental/cruse_agent/widget_no_repeat.hocon
+++ b/tests/fixtures/experimental/cruse_agent/widget_no_repeat.hocon
@@ -1,0 +1,74 @@
+
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# Widget no-repeat test: after submitting a form the agent should NOT
+# generate another widget asking for the same fields.
+# Addresses issues #104 and #90.
+
+{
+    "agent": "experimental/cruse_agent",
+
+    "connections": ["direct"],
+
+    "timeout_in_seconds": 300,
+
+    "interactions": [
+        {
+            # Turn 1: User asks to book a hotel — agent should ask for details.
+            # sly_data seeds selected_agent so domain_expert (CallAgent) knows which agent to call.
+            "sly_data": {
+                "selected_agent": "industry/booking"
+            },
+
+            "text": "I want to book a hotel room in downtown Santa Cruz",
+
+            "continue_conversation": true,
+
+            "response": {
+                "text": {
+                    "gist": "The assistant responds about hotel booking in Santa Cruz"
+                }
+            }
+        },
+        {
+            # Turn 2: User submits the form — agent should NOT re-ask for dates/budget.
+            # sly_data also seeds widget_state to simulate what the backend would have set.
+            "sly_data": {
+                "selected_agent": "industry/booking",
+                "widget_state": {
+                    "submitted_fields": ["checkInDate", "checkOutDate", "budget"],
+                    "submission_data": {
+                        "checkInDate": "2026-03-09",
+                        "checkOutDate": "2026-03-10",
+                        "budget": 250
+                    }
+                }
+            },
+
+            "text": "Form submitted:\n• Check In Date: 2026-03-09\n• Check Out Date: 2026-03-10\n• Budget: $250\n\nForm submission context: {'checkInDate': '2026-03-09', 'checkOutDate': '2026-03-10', 'budget': 250}",
+
+            "continue_conversation": true,
+
+            "response": {
+                "text": {
+                    "gist": "The assistant acknowledges the booking details and provides options or next steps",
+                    "not_gist": "The assistant asks again for check-in date, check-out date, or budget that was already provided"
+                }
+            }
+        }
+    ]
+}

--- a/tests/integration/test_integration_test_hocons.py
+++ b/tests/integration/test_integration_test_hocons.py
@@ -221,6 +221,11 @@ class TestIntegrationTestHocons(TestCase, FailFastParamMixin):
                 "experimental/copy_cat/copy_hello_world.hocon",
                 "experimental/mdap_decomposer/long_multiplication.hocon",
                 "experimental/mdap_decomposer/list_sorting.hocon",
+                # Widget behavior fixes (#141, #104, #101, #90, #14)
+                "experimental/cruse_agent/widget_no_repeat.hocon",
+                "experimental/cruse_agent/widget_matches_context.hocon",
+                "experimental/cruse_agent/widget_info_no_widget.hocon",
+                "experimental/cruse_agent/widget_multi_turn.hocon",
                 # List more hocon files as they become available here.
             ]
         ),


### PR DESCRIPTION
## Summary

- **WidgetTemplateProvider** reads `sly_data["widget_state"]` and exposes previously submitted fields to the LLM, preventing duplicate widgets across turns (#101, #90, #14)
- **cruse_agent.hocon** rewritten so `widget_generator` is called conditionally - suppressed after form submissions and for informational responses (#141, #104, #101, #90)
- **main.py** seeds `sly_data["widget_state"]` with form submission data so coded tools know which fields were already collected (#104, #90)
- **streaming_bridge.py** persists widget schema to message metadata for debugging (#141)
- **response_parser.py** fixes a crash on `None` input (#101)

## Issues closed

Closes #141, #104, #101, #90, #14

## Tests

- 30 unit tests added (`test_widget_template_provider`, `test_response_parser`) - all passing
- 4 gist integration fixtures verified live against real LLM:
  - `widget_no_repeat` - no duplicate widget after form submit
  - `widget_matches_context` - widget topic matches domain expert response
  - `widget_info_no_widget` - casual question produces no widget
  - `widget_multi_turn` - partial form submission asks only remaining fields

